### PR TITLE
Don't update framebuffer status for opaque framebuffers

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -175,10 +175,12 @@ impl WebGLFramebuffer {
     }
 
     pub fn bind(&self, target: u32) {
-        // Update the framebuffer status on binding.  It may have
-        // changed if its attachments were resized or deleted while
-        // we've been unbound.
-        self.update_status();
+        if !self.is_in_xr_session() {
+            // Update the framebuffer status on binding.  It may have
+            // changed if its attachments were resized or deleted while
+            // we've been unbound.
+            self.update_status();
+        }
 
         self.target.set(Some(target));
         self.upcast::<WebGLObject>()


### PR DESCRIPTION
This allows the babylon demos to render _something_.